### PR TITLE
Updated the way to start the app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ To develop and test Code-Generator:
 When developing the app and new templates, run the app in dev mode:
 
 ```sh
-DEV_MODE=1 streamlit run app/streamlit_app.py
+DEV_MODE=1 streamlit run streamlit_app.py
 ```
 
 This allows to run and debug the generated templates from the `dist` folder.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 80
 
-CMD ["bash", "-c", "streamlit run --browser.serverAddress 0.0.0.0 --server.port 80 app/streamlit_app.py"]
+CMD ["bash", "-c", "streamlit run --browser.serverAddress 0.0.0.0 --server.port 80 streamlit_app.py"]

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -4,8 +4,9 @@ import tempfile
 from pathlib import Path
 
 import streamlit as st
-from codegen import CodeGenerator
-from utils import import_from_file
+
+from app.codegen import CodeGenerator
+from app.utils import import_from_file
 
 __version__ = "0.1.0"
 DEV_MODE = int(os.getenv("DEV_MODE", 0)) == 1


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Now we launch it as `streamlit run streamlit_app.py` only
- This will allow to deploy on share.streamlit with shortened url

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New feature
- [x] Other
