### PR TITLE
fix: empty `store.code` after changing templates

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -61,6 +61,7 @@ export function saveConfig(key, value) {
 export function genCode() {
   const currentFiles = files[store.config.template]
   if (currentFiles && Object.keys(currentFiles).length) {
+    store.code = {}
     for (const file in currentFiles) {
       if (!store.config.include_test && file === 'test_all.py') {
         delete store.code['test_all.py']

--- a/src/store.js
+++ b/src/store.js
@@ -60,8 +60,8 @@ export function saveConfig(key, value) {
 // render the code if there are fetched files for current selected template
 export function genCode() {
   const currentFiles = files[store.config.template]
+  store.code = {}
   if (currentFiles && Object.keys(currentFiles).length) {
-    store.code = {}
     for (const file in currentFiles) {
       if (!store.config.include_test && file === 'test_all.py') {
         delete store.code['test_all.py']

--- a/src/templates/templates.json
+++ b/src/templates/templates.json
@@ -35,8 +35,8 @@
   "template-text-classification": [
     "README.md",
     "config.yaml",
-    "main.py",
     "data.py",
+    "main.py",
     "model.py",
     "trainers.py",
     "utils.py",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Reset `store.code` to empty object after changing templates

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Other
