### PR TITLE
ci: split workflow into several jobs, exclude launch for vision tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        test: [all, simple, launch, spawn]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -61,21 +62,9 @@ jobs:
       - run: pnpm test:ci
       - run: sh ./scripts/run_tests.sh unzip
 
-      - name: Run all
-        run: sh ./scripts/run_tests.sh all
+      - name: "Run ${{ matrix.test }}"
+        run: sh ./scripts/run_tests.sh ${{ matrix.test }}
         if: github.event_name != 'schedule'
-
-      - name: Run simple
-        run: sh ./scripts/run_tests.sh simple
-        if: github.event_name != 'schedule'
-
-      - name: Run launch
-        run: sh ./scripts/run_tests.sh launch
-        if: github.event_name == 'schedule'
-
-      - name: Run spawn
-        run: sh ./scripts/run_tests.sh spawn
-        if: github.event_name == 'schedule'
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           sudo chmod 0600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile
-          sudo swapoff -a
+          swapon -s
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUN_SLOW_TESTS: 1
+      OMP_NUM_THREADS: 1
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +56,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel setuptools pip -Uqq
-          pip install -r ./scripts/requirements.txt -f https://download.pytorch.org/whl/cpu/torch_stable.html --progress-bar off
+          pip install -r ./scripts/requirements.txt -f https://download.pytorch.org/whl/cpu/torch_stable.html -q
           pip uninstall -y tqdm
           npm i -g pnpm
           pnpm i --frozen-lockfile --color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
         test: [all, simple, launch, spawn]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Free up some space
+        run: |
+          sudo apt-get autoremove -y
+          sudo apt-get autoclean  -y
+          sudo apt-get clean -y
+          docker system prune --all --force
+          docker system prune --all --force --volumes
+          sudo dd if=/dev/zero of=/swapfile bs=1M count=16384
+          sudo chmod 0600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapoff -a
+
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        template:
+          [
+            text-classification,
+            vision-dcgan,
+            vision-classification,
+            vision-segmentation
+          ]
         test: [all, simple, launch, spawn]
     steps:
       - uses: actions/checkout@v2
@@ -62,8 +69,8 @@ jobs:
       - run: pnpm test:ci
       - run: sh ./scripts/run_tests.sh unzip
 
-      - name: "Run ${{ matrix.test }}"
-        run: sh ./scripts/run_tests.sh ${{ matrix.test }}
+      - name: 'Run ${{ matrix.template }} ${{ matrix.test }}'
+        run: sh ./scripts/run_tests.sh ${{ matrix.test }} ${{ matrix.template }}
         if: github.event_name != 'schedule'
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
             vision-segmentation
           ]
         test: [all, simple, launch, spawn]
+        exclude:
+          - template: vision-classification
+            test: launch
+          - template: vision-segmentation
+            test: launch
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,6 @@ jobs:
         test: [all, simple, launch, spawn]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Free up some space
-        run: |
-          sudo apt-get autoremove -y
-          sudo apt-get autoclean  -y
-          sudo apt-get clean -y
-          docker system prune --all --force
-          docker system prune --all --force --volumes
-          sudo dd if=/dev/zero of=/swapfile bs=1M count=16384
-          sudo chmod 0600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          swapon -s
-
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "test": "jest --color",
+    "test": "jest --color --runInBand",
     "test:ci": "start-server-and-test serve 5000 test",
     "release": "node scripts/release.js",
     "fmt": "prettier --write . && bash scripts/run_code_style.sh fmt",

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -19,8 +19,8 @@ run_simple() {
   do
     cd $dir
     python main.py --data_path ~/data \
-      --train_batch_size 4 \
-      --eval_batch_size 4 \
+      --train_batch_size 2 \
+      --eval_batch_size 1 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
@@ -35,8 +35,8 @@ run_all() {
     cd $dir
     pytest -vra --color=yes --tb=short test_*.py
     python main.py --data_path ~/data \
-      --train_batch_size 4 \
-      --eval_batch_size 4 \
+      --train_batch_size 2 \
+      --eval_batch_size 1 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
@@ -52,8 +52,8 @@ run_launch() {
     python -m torch.distributed.launch \
       --nproc_per_node 2 --use_env \
       main.py --backend gloo --data_path ~/data \
-      --train_batch_size 4 \
-      --eval_batch_size 4 \
+      --train_batch_size 2 \
+      --eval_batch_size 1 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
@@ -68,8 +68,8 @@ run_spawn() {
     cd $dir
     python main.py --data_path ~/data \
       --nproc_per_node 2 --backend gloo \
-      --train_batch_size 4 \
-      --eval_batch_size 4 \
+      --train_batch_size 2 \
+      --eval_batch_size 1 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -79,7 +79,7 @@ run_spawn() {
 }
 
 if [ $1 = "unzip" ]; then
-  unzip_all $2
+  unzip_all
 elif [ $1 = "simple" ]; then
   run_simple $2
 elif [ $1 = "all" ]; then

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -20,7 +20,7 @@ run_simple() {
     cd $dir
     python main.py --data_path ~/data \
       --train_batch_size 2 \
-      --eval_batch_size 1 \
+      --eval_batch_size 2 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
@@ -36,7 +36,7 @@ run_all() {
     pytest -vra --color=yes --tb=short test_*.py
     python main.py --data_path ~/data \
       --train_batch_size 2 \
-      --eval_batch_size 1 \
+      --eval_batch_size 2 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
@@ -53,7 +53,7 @@ run_launch() {
       --nproc_per_node 2 --use_env \
       main.py --backend gloo --data_path ~/data \
       --train_batch_size 2 \
-      --eval_batch_size 1 \
+      --eval_batch_size 2 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
@@ -69,7 +69,7 @@ run_spawn() {
     python main.py --data_path ~/data \
       --nproc_per_node 2 --backend gloo \
       --train_batch_size 2 \
-      --eval_batch_size 1 \
+      --eval_batch_size 2 \
       --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -67,8 +67,8 @@ run_spawn() {
   do
     cd $dir
     python main.py --data_path ~/data \
-      --nproc_per_node 2 --backend gloo \
-      --train_batch_size 4 \
+      --nproc_per_node 1 --backend gloo \
+      --train_batch_size 2 \
       --eval_batch_size 2 \
       --num_workers 1 \
       --max_epochs 2 \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -68,7 +68,7 @@ run_spawn() {
     cd $dir
     python main.py --data_path ~/data \
       --nproc_per_node 2 --backend gloo \
-      --train_batch_size 2 \
+      --train_batch_size 4 \
       --eval_batch_size 2 \
       --num_workers 1 \
       --max_epochs 2 \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -54,7 +54,7 @@ run_launch() {
       main.py --backend gloo --data_path ~/data \
       --train_batch_size 2 \
       --eval_batch_size 2 \
-      --num_workers 2 \
+      --num_workers 1 \
       --max_epochs 2 \
       --train_epoch_length 4 \
       --eval_epoch_length 4
@@ -70,7 +70,7 @@ run_spawn() {
       --nproc_per_node 2 --backend gloo \
       --train_batch_size 4 \
       --eval_batch_size 4 \
-      --num_workers 2 \
+      --num_workers 1 \
       --max_epochs 2 \
       --train_epoch_length 4 \
       --eval_epoch_length 4

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -70,7 +70,7 @@ run_spawn() {
       --nproc_per_node 2 --backend gloo \
       --train_batch_size 2 \
       --eval_batch_size 2 \
-      --num_workers 2 \
+      --num_workers 1 \
       --max_epochs 2 \
       --train_epoch_length 4 \
       --eval_epoch_length 4

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -15,7 +15,7 @@ unzip_all() {
 }
 
 run_simple() {
-  for dir in $(find ./dist-tests/*-simple -type d)
+  for dir in $(find ./dist-tests/$1-simple -type d)
   do
     cd $dir
     python main.py --data_path ~/data \
@@ -30,7 +30,7 @@ run_simple() {
 }
 
 run_all() {
-  for dir in $(find ./dist-tests/*-all -type d)
+  for dir in $(find ./dist-tests/$1-all -type d)
   do
     cd $dir
     pytest -vra --color=yes --tb=short test_*.py
@@ -46,7 +46,7 @@ run_all() {
 }
 
 run_launch() {
-  for dir in $(find ./dist-tests/*-launch -type d)
+  for dir in $(find ./dist-tests/$1-launch -type d)
   do
     cd $dir
     python -m torch.distributed.launch \
@@ -63,14 +63,14 @@ run_launch() {
 }
 
 run_spawn() {
-  for dir in $(find ./dist-tests/*-spawn -type d)
+  for dir in $(find ./dist-tests/$1-spawn -type d)
   do
     cd $dir
     python main.py --data_path ~/data \
-      --nproc_per_node 1 --backend gloo \
-      --train_batch_size 2 \
-      --eval_batch_size 2 \
-      --num_workers 1 \
+      --nproc_per_node 2 --backend gloo \
+      --train_batch_size 4 \
+      --eval_batch_size 4 \
+      --num_workers 2 \
       --max_epochs 2 \
       --train_epoch_length 4 \
       --eval_epoch_length 4
@@ -79,13 +79,13 @@ run_spawn() {
 }
 
 if [ $1 = "unzip" ]; then
-  unzip_all
+  unzip_all $2
 elif [ $1 = "simple" ]; then
-  run_simple
+  run_simple $2
 elif [ $1 = "all" ]; then
-  run_all
+  run_all $2
 elif [ $1 = "launch" ]; then
-  run_launch
+  run_launch $2
 elif [ $1 = "spawn" ]; then
-  run_spawn
+  run_spawn $2
 fi

--- a/src/templates/template-vision-segmentation/models.py
+++ b/src/templates/template-vision-segmentation/models.py
@@ -1,5 +1,5 @@
-from torchvision.models.segmentation import deeplabv3_resnet101
+from torchvision.models.segmentation import deeplabv3_resnet50
 
 
 def setup_model(config):
-    return deeplabv3_resnet101(num_classes=config.num_classes)
+    return deeplabv3_resnet50(num_classes=config.num_classes)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Split Ci workflow into several jobs: all, simple, launch, spawn

Fix # <!-- Please insert the issue number this PR solves -->

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New feature
- [x] Other
