### PR TITLE
fix(404): navbar not cover 404 content anymore

### DIFF
--- a/src/views/PageNotFound.vue
+++ b/src/views/PageNotFound.vue
@@ -65,8 +65,8 @@ h1 {
 .footer {
   position: absolute;
   bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
   width: 100vw;
   margin: auto;
 }

--- a/src/views/PageNotFound.vue
+++ b/src/views/PageNotFound.vue
@@ -62,11 +62,11 @@ h1 {
   color: var(--c-brand-red);
 }
 
-.footer{
+.footer {
   position: absolute;
   bottom: 0;
   left: 50%;
-  transform:translateX(-50%);
+  transform: translateX(-50%);
   width: 100vw;
   margin: auto;
 }

--- a/src/views/PageNotFound.vue
+++ b/src/views/PageNotFound.vue
@@ -11,7 +11,7 @@
         >.
       </p>
     </div>
-    <Footer />
+    <Footer class="footer" />
   </main>
 </template>
 
@@ -52,6 +52,7 @@ h1 {
   color: var(--c-brand-red);
 }
 .heading {
+  padding-top: 12rem;
   max-width: 75vw;
   margin: auto;
   text-align: center;
@@ -59,5 +60,14 @@ h1 {
 .heading .alt {
   background: var(--c-white);
   color: var(--c-brand-red);
+}
+
+.footer{
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform:translateX(-50%);
+  width: 100vw;
+  margin: auto;
 }
 </style>


### PR DESCRIPTION
![A (1)](https://user-images.githubusercontent.com/73098407/135993327-dd98f024-55e4-4b19-aa00-4450865af87a.png)


Now navbar will not cover the h1 tag.

fix #180

### What is the purpose of this pull request?

- [x] Bug fix
