### PR TITLE
Fix LRScheduler issue of PyTorch

### DIFF
--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -11,9 +11,13 @@ from ignite.metrics import Accuracy, Loss
 from ignite.utils import manual_seed
 from models import TransformerModel
 from torch import nn, optim
-from torch.optim.lr_scheduler import _LRScheduler
 from trainers import setup_evaluator, setup_trainer
 from utils import *
+
+try:
+    from torch.optim.lr_scheduler import _LRScheduler as PyTorchLRScheduler
+except ImportError:
+    from torch.optim.lr_scheduler import LRScheduler as PyTorchLRScheduler
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"  # remove tokenizer paralleism warning
 
@@ -78,10 +82,10 @@ def run(local_rank: int, config: Any):
     (config.output_dir / "config-lock.yaml").write_text(yaml.dump(config))
     trainer.logger = evaluator.logger = logger
 
-    if isinstance(lr_scheduler, _LRScheduler):
+    if isinstance(lr_scheduler, PyTorchLRScheduler):
         trainer.add_event_handler(
             Events.ITERATION_COMPLETED,
-            lambda engine: cast(_LRScheduler, lr_scheduler).step(),
+            lambda engine: cast(PyTorchLRScheduler, lr_scheduler).step(),
         )
     elif isinstance(lr_scheduler, LRScheduler):
         trainer.add_event_handler(Events.ITERATION_COMPLETED, lr_scheduler)

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     from torch.optim.lr_scheduler import _LRScheduler as PyTorchLRScheduler
 
+
 def run(local_rank: int, config: Any):
     # make a certain seed
     rank = idist.get_rank()

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -11,11 +11,15 @@ from ignite.metrics import ConfusionMatrix, IoU, mIoU
 from ignite.utils import manual_seed
 from models import setup_model
 from torch import nn, optim
-from torch.optim.lr_scheduler import _LRScheduler, LambdaLR
+from torch.optim.lr_scheduler import LambdaLR
 from trainers import setup_evaluator, setup_trainer
 from utils import *
 from vis import predictions_gt_images_handler
 
+try:
+    from torch.optim.lr_scheduler import LRScheduler as PyTorchLRScheduler
+except ImportError:
+    from torch.optim.lr_scheduler import _LRScheduler as PyTorchLRScheduler
 
 def run(local_rank: int, config: Any):
     # make a certain seed
@@ -71,10 +75,10 @@ def run(local_rank: int, config: Any):
     (config.output_dir / "config-lock.yaml").write_text(yaml.dump(config))
     trainer.logger = evaluator.logger = logger
 
-    if isinstance(lr_scheduler, _LRScheduler):
+    if isinstance(lr_scheduler, PyTorchLRScheduler):
         trainer.add_event_handler(
             Events.ITERATION_COMPLETED,
-            lambda engine: cast(_LRScheduler, lr_scheduler).step(),
+            lambda engine: cast(PyTorchLRScheduler, lr_scheduler).step(),
         )
     elif isinstance(lr_scheduler, LRScheduler):
         trainer.add_event_handler(Events.ITERATION_COMPLETED, lr_scheduler)


### PR DESCRIPTION
- PyTorch 2.0.0 has deprecated _LRScheduler, use LRScheduler instead
- Imported _LRScheduler or LRScheduler as PyTorchLRScheduler

<!-- Thank you for contributing! -->

### Description

Fix #232 

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Other
