### PR TITLE
Restructured Config, made epoch_length optional

### DIFF
--- a/src/templates/template-vision-segmentation/config.yaml
+++ b/src/templates/template-vision-segmentation/config.yaml
@@ -4,8 +4,6 @@ train_batch_size: 32
 eval_batch_size: 32
 num_workers: 4
 max_epochs: 20
-train_epoch_length: 1000
-eval_epoch_length: 1000
 lr: 0.007
 use_amp: false
 debug: false

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -34,6 +34,16 @@ def run(local_rank: int, config: Any):
     dataloader_train, dataloader_eval = setup_data(config)
     le = len(dataloader_train)
 
+    try:
+        config.eval_epoch_length
+    except AttributeError:
+        config.eval_epoch_length = None
+
+    try:
+        config.train_epoch_length
+    except AttributeError:
+        config.train_epoch_length = None
+
     # model, optimizer, loss function, device
     device = idist.device()
     model = idist.auto_model(setup_model(config))
@@ -197,7 +207,7 @@ def run(local_rank: int, config: Any):
 
 # main entrypoint
 def main():
-    config = setup_parser().parse_args()
+    config = setup_config()
     #::: if (it.dist === 'spawn') { :::#
     #::: if (it.nproc_per_node && it.nnodes > 1 && it.master_addr && it.master_port) { :::#
     kwargs = {


### PR DESCRIPTION
- Restructured config so that arguments are defined in cofing.yaml
- made train_epoch_length and eval_epoch_length optional

<!-- Thank you for contributing! -->

### Description

Fix #233 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New feature
    - Feature Request: Config file should not require those parameters
- [ ] Other

