### PR TITLE
Added optional attributes

### DIFF
--- a/src/templates/template-common/config.yaml
+++ b/src/templates/template-common/config.yaml
@@ -4,8 +4,6 @@ train_batch_size: 32
 eval_batch_size: 32
 num_workers: 4
 max_epochs: 20
-train_epoch_length: 1000
-eval_epoch_length: 1000
 use_amp: false
 debug: false
 

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -64,6 +64,10 @@ def setup_config(parser=None):
     with open(config_path, "r") as f:
         config = yaml.safe_load(f.read())
 
+    optional_attributes = ["train_epoch_length", "eval_epoch_length"]
+    for attr in optional_attributes:
+        config[attr] = config.get(attr, None)
+
     for k, v in config.items():
         setattr(args, k, v)
 


### PR DESCRIPTION
- train_epoch_length and eval_epoch_length have been set as optional according to engine definition

<!-- Thank you for contributing! -->

### Made some of the attributes optional

Fix #233 

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New feature
- [ ] Other
