### PR TITLE
Change default Namespace to Omegaconf and new method to save config-lock.yaml for reproducibility

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,3 +8,4 @@ pytest
 transformers
 datasets
 tensorboard
+omegaconf

--- a/src/templates/template-common/config.yaml
+++ b/src/templates/template-common/config.yaml
@@ -6,6 +6,8 @@ num_workers: 4
 max_epochs: 20
 use_amp: false
 debug: false
+train_epoch_length: null
+eval_epoch_length: null
 
 #::: if (it.dist === 'spawn') { :::#
 # distributed spawn

--- a/src/templates/template-common/requirements.txt
+++ b/src/templates/template-common/requirements.txt
@@ -2,6 +2,7 @@ torch>=1.10.2
 torchvision>=0.11.3
 pytorch-ignite>=0.4.8
 pyyaml
+omegaconf
 
 #::: if (['neptune', 'polyaxon'].includes(it.logger)) { :::#
 

--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -1,10 +1,10 @@
 def test_save_config():
     with open("./config.yaml", "r") as f:
-        config = yaml.safe_load(f)
+        config = OmegaConf.load(f)
 
     save_config(config, "./")
 
     with open("./config-lock.yaml", "r") as f:
-        test_config = yaml.safe_load(f)
+        test_config = OmegaConf.load(f)
 
     assert config == test_config

--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -2,9 +2,9 @@ def test_save_config():
     with open("./config.yaml", "r") as f:
         config = yaml.safe_load(f.read())
 
-    save_config(config, "./save-config-test.yaml")
+    save_config(config, "./")
 
-    with open("./", "r") as f:
+    with open("./config-lock.yaml", "r") as f:
         test_config = yaml.safe_load(f.read())
 
     assert config == test_config

--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -1,10 +1,10 @@
 def test_save_config():
     with open("./config.yaml", "r") as f:
-        config = yaml.safe_load(f.read())
+        config = yaml.safe_load(f)
 
     save_config(config, "./")
 
     with open("./config-lock.yaml", "r") as f:
-        test_config = yaml.safe_load(f.read())
+        test_config = yaml.safe_load(f)
 
     assert config == test_config

--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -1,0 +1,10 @@
+def test_save_config():
+    with open("./config.yaml", "r") as f:
+        config = yaml.safe_load(f.read())
+
+    save_config(config, "./save-config-test.yaml")
+
+    with open("./", "r") as f:
+        test_config = yaml.safe_load(f.read())
+
+    assert config == test_config

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -7,7 +7,6 @@ from typing import Any, Mapping, Optional, Union
 
 import ignite.distributed as idist
 import torch
-import yaml
 from ignite.contrib.engines import common
 from ignite.engine import Engine
 
@@ -58,10 +57,9 @@ def setup_config(parser=None):
     args = parser.parse_args()
     config_path = args.config
 
-    with open(config_path, "r") as f:
-        config = yaml.safe_load(f.read())
+    config = OmegaConf.load(config_path)
 
-    config["backend"] = args.backend
+    config.backend = args.backend
 
     return DictConfig(config)
 

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -35,6 +35,7 @@ from ignite.handlers.time_limit import TimeLimit
 
 #::: } :::#
 from ignite.utils import setup_logger
+from omegaconf import DictConfig
 
 
 def get_default_parser():
@@ -64,10 +65,7 @@ def setup_config(parser=None):
     for attr in optional_attributes:
         config[attr] = config.get(attr, None)
 
-    for k, v in config.items():
-        setattr(args, k, v)
-
-    return args
+    return DictConfig(config)
 
 
 def log_metrics(engine: Engine, tag: str) -> None:
@@ -136,6 +134,14 @@ def setup_output_dir(config: Any, rank: int) -> Path:
         config.output_dir = path.as_posix()
 
     return Path(idist.broadcast(config.output_dir, src=0))
+
+
+def save_config(config, output_dir):
+    """Save configuration to config-lock.yaml for result reproducibility."""
+    with open(f"{output_dir}/config-lock.yaml", "w+") as f:
+        for key, value in config.items():
+            if value is not None:
+                f.write(f"{key}: {value}\n")
 
 
 def setup_logging(config: Any) -> Logger:

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -35,7 +35,7 @@ from ignite.handlers.time_limit import TimeLimit
 
 #::: } :::#
 from ignite.utils import setup_logger
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 
 def get_default_parser():
@@ -61,9 +61,7 @@ def setup_config(parser=None):
     with open(config_path, "r") as f:
         config = yaml.safe_load(f.read())
 
-    optional_attributes = ["train_epoch_length", "eval_epoch_length"]
-    for attr in optional_attributes:
-        config[attr] = config.get(attr, None)
+    config["backend"] = args.backend
 
     return DictConfig(config)
 
@@ -138,10 +136,8 @@ def setup_output_dir(config: Any, rank: int) -> Path:
 
 def save_config(config, output_dir):
     """Save configuration to config-lock.yaml for result reproducibility."""
-    with open(f"{output_dir}/config-lock.yaml", "w+") as f:
-        for key, value in config.items():
-            if value is not None:
-                f.write(f"{key}: {value}\n")
+    with open(f"{output_dir}/config-lock.yaml", "w") as f:
+        OmegaConf.save(config, f)
 
 
 def setup_logging(config: Any) -> Logger:

--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -22,9 +22,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    output_dir = setup_output_dir(config, rank)
+    config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, output_dir)
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -1,6 +1,5 @@
 import os
 from pprint import pformat
-from shutil import copy
 from typing import Any
 
 import ignite.distributed as idist
@@ -69,7 +68,7 @@ def run(local_rank: int, config: Any):
     # setup engines logger with python logging
     # print training configurations
     logger = setup_logging(config)
-    logger.info("Configuration: \n%s", pformat(vars(config)))
+    logger.info("Configuration: \n%s", pformat(config))
     trainer.logger = evaluator.logger = logger
 
     trainer.add_event_handler(Events.ITERATION_COMPLETED, lr_scheduler)

--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -22,9 +22,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -25,7 +25,7 @@ def run(local_rank: int, config: Any):
     # create output folder and copy config file to output dir
     config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        copy(config.config, f"{config.output_dir}/config-lock.yaml")
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-text-classification/test_all.py
+++ b/src/templates/template-text-classification/test_all.py
@@ -4,10 +4,12 @@ from typing import Iterable
 
 import ignite.distributed as idist
 import pytest
+import yaml
 from data import setup_data
 from torch import nn, optim
 from torch.functional import Tensor
 from torch.utils.data import DataLoader
+from utils import save_config
 
 
 def set_up():
@@ -45,3 +47,6 @@ def test_setup_data():
     assert isinstance(eval_batch["attention_mask"], Tensor)
     assert isinstance(eval_batch["token_type_ids"], Tensor)
     assert isinstance(eval_batch["label"], Tensor)
+
+
+#::= from_template_common ::#

--- a/src/templates/template-text-classification/test_all.py
+++ b/src/templates/template-text-classification/test_all.py
@@ -6,6 +6,7 @@ import ignite.distributed as idist
 import pytest
 import yaml
 from data import setup_data
+from omegaconf import OmegaConf
 from torch import nn, optim
 from torch.functional import Tensor
 from torch.utils.data import DataLoader

--- a/src/templates/template-text-classification/test_all.py
+++ b/src/templates/template-text-classification/test_all.py
@@ -4,7 +4,6 @@ from typing import Iterable
 
 import ignite.distributed as idist
 import pytest
-import yaml
 from data import setup_data
 from omegaconf import OmegaConf
 from torch import nn, optim

--- a/src/templates/template-vision-classification/main.py
+++ b/src/templates/template-vision-classification/main.py
@@ -22,7 +22,7 @@ def run(local_rank: int, config: Any):
     # create output folder and copy config file to output dir
     config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        copy(config.config, f"{config.output_dir}/config-lock.yaml")
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-classification/main.py
+++ b/src/templates/template-vision-classification/main.py
@@ -19,9 +19,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    output_dir = setup_output_dir(config, rank)
+    config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, output_dir)
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-classification/main.py
+++ b/src/templates/template-vision-classification/main.py
@@ -1,5 +1,4 @@
 from pprint import pformat
-from shutil import copy
 from typing import Any
 
 import ignite.distributed as idist
@@ -59,7 +58,7 @@ def run(local_rank: int, config: Any):
     # setup engines logger with python logging
     # print training configurations
     logger = setup_logging(config)
-    logger.info("Configuration: \n%s", pformat(vars(config)))
+    logger.info("Configuration: \n%s", pformat(config))
     trainer.logger = evaluator.logger = logger
 
     trainer.add_event_handler(Events.ITERATION_COMPLETED, lr_scheduler)

--- a/src/templates/template-vision-classification/main.py
+++ b/src/templates/template-vision-classification/main.py
@@ -19,9 +19,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-classification/test_all.py
+++ b/src/templates/template-vision-classification/test_all.py
@@ -5,10 +5,12 @@ from typing import Iterable
 import ignite.distributed as idist
 import pytest
 import torch
+import yaml
 from data import setup_data
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_evaluator
+from utils import save_config
 
 
 def set_up():
@@ -48,3 +50,6 @@ def test_setup_evaluator():
     evaluator = setup_evaluator(config, model, device)
     evaluator.run([batch, batch])
     assert isinstance(evaluator.state.output, tuple)
+
+
+#::= from_template_common ::#

--- a/src/templates/template-vision-classification/test_all.py
+++ b/src/templates/template-vision-classification/test_all.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import yaml
 from data import setup_data
+from omegaconf import OmegaConf
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_evaluator

--- a/src/templates/template-vision-classification/test_all.py
+++ b/src/templates/template-vision-classification/test_all.py
@@ -5,7 +5,6 @@ from typing import Iterable
 import ignite.distributed as idist
 import pytest
 import torch
-import yaml
 from data import setup_data
 from omegaconf import OmegaConf
 from torch import nn, optim, Tensor

--- a/src/templates/template-vision-dcgan/main.py
+++ b/src/templates/template-vision-dcgan/main.py
@@ -22,9 +22,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval, num_channels = setup_data(config)

--- a/src/templates/template-vision-dcgan/main.py
+++ b/src/templates/template-vision-dcgan/main.py
@@ -1,5 +1,4 @@
 from pprint import pformat
-from shutil import copy
 from typing import Any
 
 import ignite.distributed as idist
@@ -74,7 +73,7 @@ def run(local_rank: int, config: Any):
     # setup engines logger with python logging
     # print training configurations
     logger = setup_logging(config)
-    logger.info("Configuration: \n%s", pformat(vars(config)))
+    logger.info("Configuration: \n%s", pformat(config))
     trainer.logger = evaluator.logger = logger
 
     #::: if (it.save_training || it.save_evaluation) { :::#

--- a/src/templates/template-vision-dcgan/main.py
+++ b/src/templates/template-vision-dcgan/main.py
@@ -25,7 +25,7 @@ def run(local_rank: int, config: Any):
     # create output folder and copy config file to output dir
     config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        copy(config.config, f"{config.output_dir}/config-lock.yaml")
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval, num_channels = setup_data(config)

--- a/src/templates/template-vision-dcgan/main.py
+++ b/src/templates/template-vision-dcgan/main.py
@@ -22,9 +22,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    output_dir = setup_output_dir(config, rank)
+    config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, output_dir)
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval, num_channels = setup_data(config)

--- a/src/templates/template-vision-dcgan/test_all.py
+++ b/src/templates/template-vision-dcgan/test_all.py
@@ -5,11 +5,13 @@ from typing import Iterable
 import ignite.distributed as idist
 import pytest
 import torch
+import yaml
 from data import setup_data
 from models import Discriminator, Generator
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_trainer
+from utils import save_config
 
 
 def set_up():
@@ -62,3 +64,6 @@ def test_setup_trainer():
     trainer = setup_trainer(config, model, model, optimizer, optimizer, loss_fn, device, None)
     trainer.run([batch, batch])
     assert isinstance(trainer.state.output, dict)
+
+
+#::= from_template_common ::#

--- a/src/templates/template-vision-dcgan/test_all.py
+++ b/src/templates/template-vision-dcgan/test_all.py
@@ -5,7 +5,6 @@ from typing import Iterable
 import ignite.distributed as idist
 import pytest
 import torch
-import yaml
 from data import setup_data
 from models import Discriminator, Generator
 from omegaconf import OmegaConf

--- a/src/templates/template-vision-dcgan/test_all.py
+++ b/src/templates/template-vision-dcgan/test_all.py
@@ -8,6 +8,7 @@ import torch
 import yaml
 from data import setup_data
 from models import Discriminator, Generator
+from omegaconf import OmegaConf
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_trainer

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -27,9 +27,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -30,7 +30,7 @@ def run(local_rank: int, config: Any):
     # create output folder and copy config file to output dir
     config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        copy(config.config, f"{config.output_dir}/config-lock.yaml")
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -1,6 +1,5 @@
 from functools import partial
 from pprint import pformat
-from shutil import copy
 from typing import Any, cast
 
 import ignite.distributed as idist
@@ -72,7 +71,7 @@ def run(local_rank: int, config: Any):
     # setup engines logger with python logging
     # print training configurations
     logger = setup_logging(config)
-    logger.info("Configuration: \n%s", pformat(vars(config)))
+    logger.info("Configuration: \n%s", pformat(config))
     trainer.logger = evaluator.logger = logger
 
     if isinstance(lr_scheduler, PyTorchLRScheduler):

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -27,9 +27,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    output_dir = setup_output_dir(config, rank)
+    config.output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, output_dir)
+        save_config(config, config.output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-segmentation/test_all.py
+++ b/src/templates/template-vision-segmentation/test_all.py
@@ -2,9 +2,11 @@ import os
 from argparse import Namespace
 
 import pytest
+import yaml
 from data import setup_data
 from torch import Tensor
 from torch.utils.data.dataloader import DataLoader
+from utils import save_config
 
 
 @pytest.mark.skipif(os.getenv("RUN_SLOW_TESTS", 0) == 0, reason="Skip slow tests")
@@ -26,3 +28,6 @@ def test_setup_data():
     assert isinstance(eval_batch["mask"], Tensor)
     assert eval_batch["image"].ndim == 4
     assert eval_batch["mask"].ndim == 3
+
+
+#::= from_template_common ::#

--- a/src/templates/template-vision-segmentation/test_all.py
+++ b/src/templates/template-vision-segmentation/test_all.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 import pytest
 import yaml
 from data import setup_data
+from omegaconf import OmegaConf
 from torch import Tensor
 from torch.utils.data.dataloader import DataLoader
 from utils import save_config

--- a/src/templates/template-vision-segmentation/test_all.py
+++ b/src/templates/template-vision-segmentation/test_all.py
@@ -2,7 +2,6 @@ import os
 from argparse import Namespace
 
 import pytest
-import yaml
 from data import setup_data
 from omegaconf import OmegaConf
 from torch import Tensor


### PR DESCRIPTION
<!-- Thank you for contributing! -->

This PR is to introduce [OmegaConf](https://omegaconf.readthedocs.io) as the default config dict for handling hyper parameters in templates. This will be great for the subsequent introduction of python-fire and hydra.

Also we try to have a new `save_config` method as the old method uses `shutil.py`and is quite limited in its scope to save an overridden config using command line. At last, we introduce a test function `test_save_config` to test saved by `save_config` method.

Additionally I plan to remove PyYaml file methods with OmegaConf methods as they work better with Python objects like PosixPath.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New feature
- [ ] Other
