### PR TITLE
Updated logger format

### DIFF
--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -183,7 +183,6 @@ def setup_logging(config: Any) -> Logger:
     logger = setup_logger(
         name=f"{green}[ignite]{reset}",
         level=logging.DEBUG if config.debug else logging.INFO,
-        format="%(name)s: %(message)s",
         filepath=config.output_dir / "training-info.log",
     )
     return logger


### PR DESCRIPTION
Changed logger's format in the `training-info.log` from
```
[32m[ignite][0m: Configuration: 
{'seed': 777, 'data_path': './', 'train_batch_size': 512, 'eval_batch_size': 1024, 'num_workers': 4, 'max_epochs': 20, 'use_amp': False, 'debug': False, 'train_epoch_length': None, 'eval_epoch_length': None, 'filename_prefix': 'training', 'n_saved': 2, 'save_every_iters': 1000, 'patience': 3, 'output_dir': PosixPath('logs/20230826-220744-backend-None-lr-0.0001'), 'log_every_iters': 10, 'lr': 0.0001, 'model': 'resnet18', 'backend': None, 'num_iters_per_epoch': None}
[32m[ignite][0m: Engine run starting with max_epochs=20.
[32m[ignite][0m: Engine run starting with max_epochs=1.
[32m[ignite][0m: Epoch[1] Complete. Time taken: 00:00:04.522
[32m[ignite][0m: Engine run complete. Time taken: 00:00:04.672
[32m[ignite][0m: train [1/10]: {'epoch': 1, 'train_loss': 2.417194128036499}
[32m[ignite][0m: train [1/20]: {'epoch': 1, 'train_loss': 2.387004852294922}
```
to 
```
2023-08-26 22:04:06,500 [32m[ignite][0m INFO: Configuration: 
{'seed': 777, 'data_path': './', 'train_batch_size': 512, 'eval_batch_size': 1024, 'num_workers': 4, 'max_epochs': 20, 'use_amp': False, 'debug': False, 'train_epoch_length': None, 'eval_epoch_length': None, 'filename_prefix': 'training', 'n_saved': 2, 'save_every_iters': 1000, 'patience': 3, 'output_dir': PosixPath('logs/20230826-220341-backend-None-lr-0.0001'), 'log_every_iters': 10, 'lr': 0.0001, 'model': 'resnet18', 'backend': None, 'num_iters_per_epoch': None}
2023-08-26 22:04:09,164 [32m[ignite][0m INFO: Engine run starting with max_epochs=20.
2023-08-26 22:04:09,164 [32m[ignite][0m INFO: Engine run starting with max_epochs=1.
2023-08-26 22:04:19,865 [32m[ignite][0m INFO: Epoch[1] Complete. Time taken: 00:00:10.583
2023-08-26 22:04:19,866 [32m[ignite][0m INFO: Engine run complete. Time taken: 00:00:10.702
2023-08-26 22:04:22,919 [32m[ignite][0m INFO: train [1/10]: {'epoch': 1, 'train_loss': 2.417192220687866}
2023-08-26 22:04:24,589 [32m[ignite][0m INFO: train [1/20]: {'epoch': 1, 'train_loss': 2.3869330883026123}```