### PR TITLE
Separate the output_dir and sub_output_dir to make reproducing results easier

### DIFF
--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -2,7 +2,11 @@ def test_save_config():
     with open("./config.yaml", "r") as f:
         config = OmegaConf.load(f)
 
+    config.sub_output_dir = "job-dir"
+
     save_config(config, "./")
+
+    del config["sub_output_dir"]
 
     with open("./config-lock.yaml", "r") as f:
         test_config = OmegaConf.load(f)

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -163,7 +163,7 @@ def save_config(config: Any, sub_output_dir: Path):
     """Save configuration to config-lock.yaml for result reproducibility."""
     saved_config = config.copy()
 
-    # Delete the sub_output_dir from saved in the config-lock.yaml
+    # Delete the sub_output_dir from saved_config for config-lock.yaml
     del saved_config["sub_output_dir"]
 
     with open(f"{sub_output_dir}/config-lock.yaml", "w") as f:

--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -27,9 +27,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    config.sub_output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, config.sub_output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-classification/main.py
+++ b/src/templates/template-vision-classification/main.py
@@ -24,9 +24,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    config.sub_output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, config.sub_output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-dcgan/main.py
+++ b/src/templates/template-vision-dcgan/main.py
@@ -28,9 +28,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    config.sub_output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, config.sub_output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval, num_channels = setup_data(config)
@@ -131,14 +131,14 @@ def run(local_rank: int, config: Any):
     @trainer.on(Events.EPOCH_COMPLETED)
     def save_fake_example(engine):
         fake = model_g(fixed_noise)
-        path = config.output_dir / FAKE_IMG_FNAME.format(engine.state.epoch)
+        path = config.sub_output_dir / FAKE_IMG_FNAME.format(engine.state.epoch)
         vutils.save_image(fake.detach(), path, normalize=True)
 
     # adding handlers using `trainer.on` decorator API
     @trainer.on(Events.EPOCH_COMPLETED)
     def save_real_example(engine):
         img, y = engine.state.batch
-        path = config.output_dir / REAL_IMG_FNAME.format(engine.state.epoch)
+        path = config.sub_output_dir / REAL_IMG_FNAME.format(engine.state.epoch)
         vutils.save_image(img, path, normalize=True)
 
     # run evaluation at every training epoch end

--- a/src/templates/template-vision-dcgan/utils.py
+++ b/src/templates/template-vision-dcgan/utils.py
@@ -15,7 +15,7 @@ def setup_handlers(
     ckpt_handler_train = ckpt_handler_eval = None
     #::: if (it.save_training || it.save_evaluation) { :::#
     # checkpointing
-    saver = DiskSaver(config.output_dir / "checkpoints", require_empty=False)
+    saver = DiskSaver(config.sub_output_dir / "checkpoints", require_empty=False)
     #::: if (it.save_training) { :::#
     ckpt_handler_train = Checkpoint(
         to_save_train,

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -34,9 +34,9 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    config.sub_output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, config.sub_output_dir)
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-segmentation/utils.py
+++ b/src/templates/template-vision-segmentation/utils.py
@@ -16,7 +16,7 @@ def setup_handlers(
     ckpt_handler_train = ckpt_handler_eval = None
     #::: if (it.save_training || it.save_evaluation) { :::#
     # checkpointing
-    saver = DiskSaver(config.output_dir / "checkpoints", require_empty=False)
+    saver = DiskSaver(config.sub_output_dir / "checkpoints", require_empty=False)
     #::: if (it.save_training) { :::#
     ckpt_handler_train = Checkpoint(
         to_save_train,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR introduces a distinction between `output_dir` and `sub_output_dir` in the templates. This simplifies the end result for the user to access the `logs/<job-dir>` and integration of other reproducibility based features for templates in future. 

Fix #292
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [x] Bug fix
- [x] New feature
- [ ] Other
