### PR TITLE
Fix the output_dir logic and bugs for reproducibility

### DIFF
--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -2,9 +2,14 @@ def test_save_config():
     with open("./config.yaml", "r") as f:
         config = OmegaConf.load(f)
 
-    save_config(config, "./")
+    # Add backend to config (similar to setup_config)
+    config.backend = None
 
-    with open("./config-lock.yaml", "r") as f:
+    output_dir = setup_output_dir(config, rank=0)
+
+    save_config(config, output_dir)
+
+    with open(output_dir / "config-lock.yaml", "r") as f:
         test_config = OmegaConf.load(f)
 
     assert config == test_config

--- a/src/templates/template-common/test_all.py
+++ b/src/templates/template-common/test_all.py
@@ -5,11 +5,12 @@ def test_save_config():
     # Add backend to config (similar to setup_config)
     config.backend = None
 
-    output_dir = setup_output_dir(config, rank=0)
+    with tempfile.TemporaryDirectory() as output_dir:
+        output_dir = Path(output_dir)
 
-    save_config(config, output_dir)
+        save_config(config, output_dir)
 
-    with open(output_dir / "config-lock.yaml", "r") as f:
-        test_config = OmegaConf.load(f)
+        with open(output_dir / "config-lock.yaml", "r") as f:
+            test_config = OmegaConf.load(f)
 
-    assert config == test_config
+        assert config == test_config

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -148,6 +148,7 @@ def resume_from(
 
 
 def setup_output_dir(config: Any, rank: int) -> Path:
+    """Create output folder."""
     output_dir = config.output_dir
     if rank == 0:
         now = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/src/templates/template-common/utils.py
+++ b/src/templates/template-common/utils.py
@@ -148,15 +148,14 @@ def resume_from(
 
 
 def setup_output_dir(config: Any, rank: int) -> Path:
-    """Create output folder."""
+    output_dir = config.output_dir
     if rank == 0:
         now = datetime.now().strftime("%Y%m%d-%H%M%S")
         name = f"{now}-backend-{config.backend}-lr-{config.lr}"
         path = Path(config.output_dir, name)
         path.mkdir(parents=True, exist_ok=True)
-        config.output_dir = path.as_posix()
-
-    return Path(idist.broadcast(config.output_dir, src=0))
+        output_dir = path.as_posix()
+    return Path(idist.broadcast(output_dir, src=0))
 
 
 def save_config(config, output_dir):

--- a/src/templates/template-text-classification/main.py
+++ b/src/templates/template-text-classification/main.py
@@ -27,9 +27,11 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
+
+    config.output_dir = output_dir
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-text-classification/test_all.py
+++ b/src/templates/template-text-classification/test_all.py
@@ -1,5 +1,7 @@
 import os
+import tempfile
 from argparse import Namespace
+from pathlib import Path
 from typing import Iterable
 
 import ignite.distributed as idist
@@ -9,7 +11,7 @@ from omegaconf import OmegaConf
 from torch import nn, optim
 from torch.functional import Tensor
 from torch.utils.data import DataLoader
-from utils import save_config, setup_output_dir
+from utils import save_config
 
 
 def set_up():

--- a/src/templates/template-text-classification/test_all.py
+++ b/src/templates/template-text-classification/test_all.py
@@ -9,7 +9,7 @@ from omegaconf import OmegaConf
 from torch import nn, optim
 from torch.functional import Tensor
 from torch.utils.data import DataLoader
-from utils import save_config
+from utils import save_config, setup_output_dir
 
 
 def set_up():

--- a/src/templates/template-vision-classification/main.py
+++ b/src/templates/template-vision-classification/main.py
@@ -24,9 +24,11 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
+
+    config.output_dir = output_dir
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-classification/test_all.py
+++ b/src/templates/template-vision-classification/test_all.py
@@ -1,5 +1,7 @@
 import os
+import tempfile
 from argparse import Namespace
+from pathlib import Path
 from typing import Iterable
 
 import ignite.distributed as idist
@@ -10,7 +12,7 @@ from omegaconf import OmegaConf
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_evaluator
-from utils import save_config, setup_output_dir
+from utils import save_config
 
 
 def set_up():

--- a/src/templates/template-vision-classification/test_all.py
+++ b/src/templates/template-vision-classification/test_all.py
@@ -10,7 +10,7 @@ from omegaconf import OmegaConf
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_evaluator
-from utils import save_config
+from utils import save_config, setup_output_dir
 
 
 def set_up():

--- a/src/templates/template-vision-dcgan/main.py
+++ b/src/templates/template-vision-dcgan/main.py
@@ -28,9 +28,11 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
+
+    config.output_dir = output_dir
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval, num_channels = setup_data(config)

--- a/src/templates/template-vision-dcgan/test_all.py
+++ b/src/templates/template-vision-dcgan/test_all.py
@@ -1,5 +1,7 @@
 import os
+import tempfile
 from argparse import Namespace
+from pathlib import Path
 from typing import Iterable
 
 import ignite.distributed as idist
@@ -11,7 +13,7 @@ from omegaconf import OmegaConf
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_trainer
-from utils import save_config, setup_output_dir
+from utils import save_config
 
 
 def set_up():

--- a/src/templates/template-vision-dcgan/test_all.py
+++ b/src/templates/template-vision-dcgan/test_all.py
@@ -11,7 +11,7 @@ from omegaconf import OmegaConf
 from torch import nn, optim, Tensor
 from torch.utils.data.dataloader import DataLoader
 from trainers import setup_trainer
-from utils import save_config
+from utils import save_config, setup_output_dir
 
 
 def set_up():

--- a/src/templates/template-vision-segmentation/main.py
+++ b/src/templates/template-vision-segmentation/main.py
@@ -34,9 +34,11 @@ def run(local_rank: int, config: Any):
     manual_seed(config.seed + rank)
 
     # create output folder and copy config file to output dir
-    config.output_dir = setup_output_dir(config, rank)
+    output_dir = setup_output_dir(config, rank)
     if rank == 0:
-        save_config(config, config.output_dir)
+        save_config(config, output_dir)
+
+    config.output_dir = output_dir
 
     # donwload datasets and create dataloaders
     dataloader_train, dataloader_eval = setup_data(config)

--- a/src/templates/template-vision-segmentation/test_all.py
+++ b/src/templates/template-vision-segmentation/test_all.py
@@ -1,12 +1,14 @@
 import os
+import tempfile
 from argparse import Namespace
+from pathlib import Path
 
 import pytest
 from data import setup_data
 from omegaconf import OmegaConf
 from torch import Tensor
 from torch.utils.data.dataloader import DataLoader
-from utils import save_config, setup_output_dir
+from utils import save_config
 
 
 @pytest.mark.skipif(os.getenv("RUN_SLOW_TESTS", 0) == 0, reason="Skip slow tests")

--- a/src/templates/template-vision-segmentation/test_all.py
+++ b/src/templates/template-vision-segmentation/test_all.py
@@ -6,7 +6,7 @@ from data import setup_data
 from omegaconf import OmegaConf
 from torch import Tensor
 from torch.utils.data.dataloader import DataLoader
-from utils import save_config
+from utils import save_config, setup_output_dir
 
 
 @pytest.mark.skipif(os.getenv("RUN_SLOW_TESTS", 0) == 0, reason="Skip slow tests")


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR aims to fix the problems related to reproducing results in the templates due to templates creating output in wrong directory when we try to reproduce the results using `logs/<job-dir>/config-lock.yaml`

Fix #292

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
This PR uses discussion based on  #306.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Other
