### PR TITLE
PR to improve the hash function for uuid

### DIFF
--- a/functions/utils.js
+++ b/functions/utils.js
@@ -63,6 +63,7 @@ export async function getZip_Uid(data) {
   const zip = new JSZip()
   const code = data.code
   const template = `ignite-${data.template}`
+  let fullCode = ''
 
   // As usual from Download component,
   // we will zip the files and
@@ -70,13 +71,14 @@ export async function getZip_Uid(data) {
   // with Octokit.
   const startTime = new Date()
   for (const filename in code) {
+    fullCode += code[filename]
     zip.file(filename, code[filename])
   }
   // since the generated zip varies every time even with the same code
   // it can't be used to generate a UUID
   const content = await zip.generateAsync({ type: 'base64' })
   // we generate an unique id from the current config for pushing to github
-  const nbUid = uuidv5(JSON.stringify(data.config), uuidv5.URL)
+  const nbUid = uuidv5(fullCode, uuidv5.URL)
   const endTime = new Date()
   const timeTaken = endTime - startTime
   console.log("The total time taken was: ")

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -70,7 +70,6 @@ export async function getZip_Uid(data) {
   // generate a base64 format for pushing to GitHub
   // with Octokit.
   for (const filename in code) {
-    fullCode += code[filename]
     zip.file(filename, code[filename])
   }
   // since the generated zip varies every time even with the same code
@@ -78,10 +77,10 @@ export async function getZip_Uid(data) {
   const content = await zip.generateAsync({ type: 'base64' })
   // we generate an unique id from the current config for pushing to github
   const startTime = Date.now()
-  for (const filename in code) {
-    fullCode += code[filename]
-  }
-  const nbUid = uuidv5(fullCode, uuidv5.URL)
+  // for (const filename in code) {
+  //   fullCode += code[filename]
+  // }
+  const nbUid = uuidv5(JSON.stringify(store), uuidv5.URL)
   const endTime = Date.now()
   const timeTaken = endTime - startTime
   console.log("The total time taken was: " + timeTaken + "milliseconds")

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -69,7 +69,6 @@ export async function getZip_Uid(data) {
   // we will zip the files and
   // generate a base64 format for pushing to GitHub
   // with Octokit.
-  const startTime = new Date()
   for (const filename in code) {
     fullCode += code[filename]
     zip.file(filename, code[filename])
@@ -78,11 +77,14 @@ export async function getZip_Uid(data) {
   // it can't be used to generate a UUID
   const content = await zip.generateAsync({ type: 'base64' })
   // we generate an unique id from the current config for pushing to github
+  const startTime = Date.now()
+  for (const filename in code) {
+    fullCode += code[filename]
+  }
   const nbUid = uuidv5(fullCode, uuidv5.URL)
-  const endTime = new Date()
+  const endTime = Date.now()
   const timeTaken = endTime - startTime
-  console.log("The total time taken was: ")
-  console.log(timeTaken)
+  console.log("The total time taken was: " + timeTaken + "milliseconds")
   const zipRes = await pushToGitHub(content, `${template}.zip`, nbUid)
   return {
     zipRes: zipRes,

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -68,6 +68,7 @@ export async function getZip_Uid(data) {
   // we will zip the files and
   // generate a base64 format for pushing to GitHub
   // with Octokit.
+  const startTime = new Date()
   for (const filename in code) {
     zip.file(filename, code[filename])
   }
@@ -76,6 +77,10 @@ export async function getZip_Uid(data) {
   const content = await zip.generateAsync({ type: 'base64' })
   // we generate an unique id from the current config for pushing to github
   const nbUid = uuidv5(JSON.stringify(data.config), uuidv5.URL)
+  const endTime = new Date()
+  const timeTaken = endTime - startTime
+  console.log("The total time taken was: ")
+  console.log(timeTaken)
   const zipRes = await pushToGitHub(content, `${template}.zip`, nbUid)
   return {
     zipRes: zipRes,

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -80,7 +80,7 @@ export async function getZip_Uid(data) {
   // for (const filename in code) {
   //   fullCode += code[filename]
   // }
-  const nbUid = uuidv5(JSON.stringify(store), uuidv5.URL)
+  const nbUid = uuidv5(JSON.stringify(data.config), uuidv5.URL)
   const endTime = Date.now()
   const timeTaken = endTime - startTime
   console.log("The total time taken was: " + timeTaken + "milliseconds")

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -70,20 +70,14 @@ export async function getZip_Uid(data) {
   // generate a base64 format for pushing to GitHub
   // with Octokit.
   for (const filename in code) {
+    fullCode += code[filename]
     zip.file(filename, code[filename])
   }
   // since the generated zip varies every time even with the same code
   // it can't be used to generate a UUID
   const content = await zip.generateAsync({ type: 'base64' })
   // we generate an unique id from the current config for pushing to github
-  const startTime = Date.now()
-  // for (const filename in code) {
-  //   fullCode += code[filename]
-  // }
-  const nbUid = uuidv5(JSON.stringify(data.config), uuidv5.URL)
-  const endTime = Date.now()
-  const timeTaken = endTime - startTime
-  console.log("The total time taken was: " + timeTaken + "milliseconds")
+  const nbUid = uuidv5(fullCode, uuidv5.URL)
   const zipRes = await pushToGitHub(content, `${template}.zip`, nbUid)
   return {
     zipRes: zipRes,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

- This PR aims to measure the time overhead caused by the current hashing of `store.config` and hashing of the whole code in the template.

### Additional context

Currently, uuid hashes only the current store.config, so any changes in store.config would change the uuid, but suppose we follow the steps:
1. Commit a template using x config with uuid: 53asdf
2. We then change the code in the python files, in the template, this would be reflected in the ui and won't affect the download zip option, but essentially there is no change in the store.config
3. We again try to commit a template using the same x config, so the uuid would be the same: 53asdf since the store.config is the same. This would not create a new commit like it should since we changed the py files, but fetches the template from the previous commit...


---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Other
