### PR TITLE
Fix command errors in Nebari server run for templates

### DIFF
--- a/functions/nebari.js
+++ b/functions/nebari.js
@@ -29,8 +29,8 @@ exports.handler = async function (event, _) {
     .join(' ')
 
   // get notebook cell structure
-  const nb = getNbCells(title, zipRes, argparser, template, nebari=true)
-  
+  const nb = getNbCells(title, zipRes, argparser, template, (nebari = true))
+
   // Updating UUID for nebari-test-fix
   const nbUid_nebari = nbUid + '-nebari'
 

--- a/functions/nebari.js
+++ b/functions/nebari.js
@@ -7,6 +7,7 @@ import {
 
 const repoOwner = process.env.VUE_APP_GH_USER
 const repo = process.env.VUE_APP_GH_REPO
+const commit = __COMMIT__ /* from vite.config.js */
 
 // This function is the one Netlify function runs on
 // https://docs.netlify.com/functions/build-with-javascript/#synchronous-function-format
@@ -32,7 +33,7 @@ exports.handler = async function (event, _) {
   const nb = getNbCells(title, zipRes, argparser, template, (nebari = true))
 
   // Updating UUID for nebari-test-fix
-  const nbUid_nebari = nbUid + '-nebari'
+  const nbUid_nebari = nbUid + '-nebari' + -commit
 
   // Create the notebook on GitHub
   await pushToGitHub(

--- a/functions/nebari.js
+++ b/functions/nebari.js
@@ -29,16 +29,19 @@ exports.handler = async function (event, _) {
     .join(' ')
 
   // get notebook cell structure
-  const nb = getNbCells(title, zipRes, argparser, template)
+  const nb = getNbCells(title, zipRes, argparser, template, nebari=true)
+  
+  // Updating UUID for nebari-test-fix
+  const nbUid_nebari = nbUid + '-nebari'
 
   // Create the notebook on GitHub
   await pushToGitHub(
     Buffer.from(JSON.stringify(nb)).toString('base64'),
     nbName,
-    nbUid
+    nbUid_nebari
   )
 
-  const nebariLink = `${nebariInstanceLink}/user/${userName}/lab/tree/GitHub%3A${repoOwner}/${repo}/nbs/${nbUid}/${nbName}`
+  const nebariLink = `${nebariInstanceLink}/user/${userName}/lab/tree/GitHub%3A${repoOwner}/${repo}/nbs/${nbUid_nebari}/${nbName}`
 
   return {
     statusCode: 200,

--- a/functions/nebari.js
+++ b/functions/nebari.js
@@ -4,10 +4,13 @@ import {
   getRootUrlWithoutTrailingSlash,
   getNbCells
 } from './utils'
+import { execSync } from 'child_process'
 
+const commit = JSON.stringify(
+  execSync('git rev-parse HEAD', { encoding: 'utf-8' })
+)
 const repoOwner = process.env.VUE_APP_GH_USER
 const repo = process.env.VUE_APP_GH_REPO
-const commit = __COMMIT__ /* from vite.config.js */
 
 // This function is the one Netlify function runs on
 // https://docs.netlify.com/functions/build-with-javascript/#synchronous-function-format

--- a/functions/nebari.js
+++ b/functions/nebari.js
@@ -4,11 +4,7 @@ import {
   getRootUrlWithoutTrailingSlash,
   getNbCells
 } from './utils'
-import { execSync } from 'child_process'
 
-const commit = JSON.stringify(
-  execSync('git rev-parse HEAD', { encoding: 'utf-8' })
-)
 const repoOwner = process.env.VUE_APP_GH_USER
 const repo = process.env.VUE_APP_GH_REPO
 
@@ -36,7 +32,7 @@ exports.handler = async function (event, _) {
   const nb = getNbCells(title, zipRes, argparser, template, (nebari = true))
 
   // Updating UUID for nebari-test-fix
-  const nbUid_nebari = nbUid + '-nebari' + -commit
+  const nbUid_nebari = nbUid + '-nebari'
 
   // Create the notebook on GitHub
   await pushToGitHub(

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -113,7 +113,7 @@ export function getRootUrlWithoutTrailingSlash(url) {
  * @param {boolean} nebari
  * @returns {JSON} nb
  */
-export function getNbCells(title, zipRes, argparser, template, nebari=false) {
+export function getNbCells(title, zipRes, argparser, template, nebari = false) {
   function create_nb_cell(source_array, cell_type) {
     return {
       cell_type: cell_type,
@@ -154,10 +154,12 @@ export function getNbCells(title, zipRes, argparser, template, nebari=false) {
   // To have seperate folder in Nebari server for downloading and executing files
   if (nebari) {
     common_nb_commands.unshift('%cd {cur_dir[0]}')
-    common_nb_commands.unshift('cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD')
+    common_nb_commands.unshift(
+      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD'
+    )
     execution_nb_commands.unshift('%cd {cur_dir[0]}')
   }
- 
+
   let nb_cells = [
     create_nb_cell(md_cell, 'markdown'),
     create_nb_cell(common_nb_commands, 'code')

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -153,11 +153,12 @@ export function getNbCells(title, zipRes, argparser, template, nebari = false) {
 
   // To have seperate folder in Nebari server for downloading and executing files
   if (nebari) {
-    common_nb_commands.unshift('%cd {cur_dir[0]}')
-    common_nb_commands.unshift(
-      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD'
-    )
-    execution_nb_commands.unshift('%cd {cur_dir[0]}')
+    common_nb_commands = [
+      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD',
+      `%cd {cur_dir[0]}`,
+      ...common_nb_commands
+    ]
+    execution_nb_commands = [`%cd {cur_dir[0]}`, ...execution_nb_commands]
   }
 
   let nb_cells = [

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -110,9 +110,10 @@ export function getRootUrlWithoutTrailingSlash(url) {
  * @param {string} zipRes
  * @param {string} argparser
  * @param {string} template
+ * @param {boolean} nebari
  * @returns {JSON} nb
  */
-export function getNbCells(title, zipRes, argparser, template) {
+export function getNbCells(title, zipRes, argparser, template, nebari=false) {
   function create_nb_cell(source_array, cell_type) {
     return {
       cell_type: cell_type,
@@ -136,13 +137,13 @@ export function getNbCells(title, zipRes, argparser, template) {
     'Please, run the cell below to execute your code.'
   ]
 
-  const common_nb_commands = [
+  let common_nb_commands = [
     `!wget ${zipRes}\n`,
     `!unzip ${template}.zip\n`,
     '!pip install -r requirements.txt'
   ]
 
-  const execution_nb_commands = [
+  let execution_nb_commands = [
     `!python main.py ${
       argparser === 'hydra'
         ? '#--config-dir=/content/ --config-name=config.yaml'
@@ -150,6 +151,13 @@ export function getNbCells(title, zipRes, argparser, template) {
     }`
   ]
 
+  // To have seperate folder in Nebari server for downloading and executing files
+  if (nebari) {
+    common_nb_commands.unshift('%cd {cur_dir[0]}')
+    common_nb_commands.unshift('cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD')
+    execution_nb_commands.unshift('%cd {cur_dir[0]}')
+  }
+ 
   let nb_cells = [
     create_nb_cell(md_cell, 'markdown'),
     create_nb_cell(common_nb_commands, 'code')

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -154,11 +154,11 @@ export function getNbCells(title, zipRes, argparser, template, nebari = false) {
   // To have seperate folder in Nebari server for downloading and executing files
   if (nebari) {
     common_nb_commands = [
-      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD \n',
-      `%cd {cur_dir[0]} \n`,
+      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD\n',
+      `%cd {cur_dir[0]}\n`,
       ...common_nb_commands
     ]
-    execution_nb_commands = [`%cd {cur_dir[0]} \n`, ...execution_nb_commands]
+    execution_nb_commands = [`%cd {cur_dir[0]}\n`, ...execution_nb_commands]
   }
 
   let nb_cells = [

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -154,11 +154,11 @@ export function getNbCells(title, zipRes, argparser, template, nebari = false) {
   // To have seperate folder in Nebari server for downloading and executing files
   if (nebari) {
     common_nb_commands = [
-      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD',
-      `%cd {cur_dir[0]}`,
+      'cur_dir = !mkdir pytorch-ignite-template-`date "+%Y%m%d-%H%M%S"` && cd $_ && echo $PWD \n',
+      `%cd {cur_dir[0]} \n`,
       ...common_nb_commands
     ]
-    execution_nb_commands = [`%cd {cur_dir[0]}`, ...execution_nb_commands]
+    execution_nb_commands = [`%cd {cur_dir[0]} \n`, ...execution_nb_commands]
   }
 
   let nb_cells = [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR is a follow up PR for the fixes in the code execution while testing in the Nebari server. Particularly we faced two issues, first if we open a template in Nebari, its default folder will be root and if it is the second template opened, then it will try to download and overwrite the previous one. This can be fixed by fixing the `nbuid-> nbuid + '-nebari'`. 

Also we add some extra commands that can help in creating a new directory and store templates files in that specific directory.

Fix #314

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
This issue was discussed in Discord this week.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Other
